### PR TITLE
add cconfig.h

### DIFF
--- a/projects/art_pi_blink_led/cconfig.h
+++ b/projects/art_pi_blink_led/cconfig.h
@@ -1,0 +1,18 @@
+#ifndef CCONFIG_H__
+#define CCONFIG_H__
+/* Automatically generated file; DO NOT EDIT. */
+/* compiler configure file for RT-Thread in GCC*/
+
+#define HAVE_NEWLIB_H 1
+#define LIBC_VERSION "newlib 2.4.0"
+
+#define HAVE_SYS_SIGNAL_H 1
+#define HAVE_SYS_SELECT_H 1
+#define HAVE_PTHREAD_H 1
+
+#define HAVE_FDSET 1
+#define HAVE_SIGACTION 1
+#define GCC_VERSION_STR "5.4.1 20160919 (release) [ARM/embedded-5-branch revision 240496]"
+#define STDC "2011"
+
+#endif


### PR DESCRIPTION
缺少cconfig.h, 导致scons --target=eclipse 不能执行