### PR TITLE
【修正】yaml LED 编号描述错误。使能 SD 卡编译报错。

### DIFF
--- a/RealThread_STMH750-ART-Pi.yaml
+++ b/RealThread_STMH750-ART-Pi.yaml
@@ -65,7 +65,7 @@ features_zh:
 - 32-Mbytes SDRAM
 - 16-Mbytes SPI FLASH
 - 8-Mbytes QSPI FLASH
-- D1 (blue) for 3.3 V power-on
+- D3 (blue) for 3.3 V power-on
 - "Two user LEDs: D2 (blue), D2 (red)"
 - "Two ST-LINK LEDs: D4 (blue), D4 (red)"
 - Two push-buttons (user and reset)

--- a/projects/art_pi_blink_led/board/CubeMX_Config/Core/Inc/stm32h7xx_hal_conf.h
+++ b/projects/art_pi_blink_led/board/CubeMX_Config/Core/Inc/stm32h7xx_hal_conf.h
@@ -166,7 +166,7 @@
 #define  VDD_VALUE                    ((uint32_t)3300U) /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            ((uint32_t)0U) /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
-#define  USE_SD_TRANSCEIVER           1U               /*!< use uSD Transceiver */
+#define  USE_SD_TRANSCEIVER           0U               /*!< use uSD Transceiver */
 #define  USE_SPI_CRC	              0U               /*!< use CRC in SPI */
 
 #define  USE_HAL_ADC_REGISTER_CALLBACKS     0U /* ADC register callback disabled     */

--- a/projects/art_pi_bootloader/board/CubeMX_Config/Core/Inc/stm32h7xx_hal_conf.h
+++ b/projects/art_pi_bootloader/board/CubeMX_Config/Core/Inc/stm32h7xx_hal_conf.h
@@ -166,7 +166,7 @@
 #define  VDD_VALUE                    ((uint32_t)3300U) /*!< Value of VDD in mv */
 #define  TICK_INT_PRIORITY            ((uint32_t)0U) /*!< tick interrupt priority */
 #define  USE_RTOS                     0U
-#define  USE_SD_TRANSCEIVER           1U               /*!< use uSD Transceiver */
+#define  USE_SD_TRANSCEIVER           0U               /*!< use uSD Transceiver */
 #define  USE_SPI_CRC	              0U               /*!< use CRC in SPI */
 
 #define  USE_HAL_ADC_REGISTER_CALLBACKS     0U /* ADC register callback disabled     */


### PR DESCRIPTION
1. yaml 描述的 LED 编号与图纸不符
2. conf.h 默认开启了 μsd， 使用3.3V卡 编译报错