### PR TITLE
【修复】boot blink 工程中 README 无法显示图片的问题

### DIFF
--- a/RealThread_STMH750-ART-Pi.yaml
+++ b/RealThread_STMH750-ART-Pi.yaml
@@ -80,6 +80,7 @@ template_projects:
     - ".settings"
     - applications
     - board
+    - figures
     - ".config"
     - ".cproject"
     - ".gitignore"
@@ -121,6 +122,7 @@ example_projects:
     - ".settings"
     - applications
     - board
+    - figures
     - ".config"
     - ".cproject"
     - ".gitignore"
@@ -161,6 +163,7 @@ example_projects:
     - ".settings"
     - applications
     - board
+    - figures
     - ".config"
     - ".cproject"
     - ".gitignore"

--- a/projects/art_pi_bootloader/README.md
+++ b/projects/art_pi_bootloader/README.md
@@ -8,7 +8,7 @@ STM32H750 的片上 ROM 大小为128K，无法满足一般的程序开发，必�
 
 ## 硬件说明
 
-<img src="E:\project\art-pi-sdk-github\sdk-bsp-stm32h750-realthread-artpi\projects\art_pi_bootloader\figures\qspi_flash.png" alt="qspi_flash" style="zoom:50%;" />
+<img src="./figures\qspi_flash.png" alt="qspi_flash" style="zoom:50%;" />
 
 如上图所示，QSPI_FLASH 与单片机的 QSPI 外设引脚相连。
 


### PR DESCRIPTION
修复 boot blink 工程中 README 无法显示图片的问题