### PR TITLE
【修复】sdram 初始化时间过长的问题

### DIFF
--- a/libraries/drivers/drv_sdram.c
+++ b/libraries/drivers/drv_sdram.c
@@ -51,7 +51,7 @@ static void SDRAM_Initialization_Sequence(SDRAM_HandleTypeDef *hsdram, FMC_SDRAM
 
     /* Insert 100 ms delay */
     /* interrupt is not enable, just to delay some time. */
-    for (tmpmrd = 0; tmpmrd < 0xffffff; tmpmrd ++)
+    for (tmpmrd = 0; tmpmrd < 0xffff; tmpmrd ++)
         ;
 
     /* Configure a PALL (precharge all) command */


### PR DESCRIPTION
修复 sdram 初始化时间过长的问题
