### PR TITLE
【修复】放开宏 ENABLE_LOG_INFO 时编译错误

### DIFF
--- a/projects/art_pi_factory/packages/btstack-v0.0.1/platform/posix/btstack_run_loop_posix.c
+++ b/projects/art_pi_factory/packages/btstack-v0.0.1/platform/posix/btstack_run_loop_posix.c
@@ -124,10 +124,13 @@ static bool btstack_run_loop_posix_remove_timer(btstack_timer_source_t *ts){
 
 static void btstack_run_loop_posix_dump_timer(void){
     btstack_linked_item_t *it;
+#ifdef ENABLE_LOG_INFO
+    int i = 0;
+#endif
     for (it = (btstack_linked_item_t *) timers; it ; it = it->next){
 #ifdef ENABLE_LOG_INFO
         btstack_timer_source_t *ts = (btstack_timer_source_t*) it;
-        log_info("timer %u (%p): timeout %u\n", i, ts, ts->timeout);
+        log_info("timer %u (%p): timeout %u\n", i++, ts, ts->timeout);
 #endif
     }
 }


### PR DESCRIPTION
调试时发现放开宏时 ENABLE_LOG_INFO 时，编译出错，提示变量 i 未定义，对比官方的 btstack 库源文件，补充对变量 i 的定义，然后测试编译通过。