### PR TITLE
【完善】 scons --menuconfig 更新 rtconfig.h 文件的邏輯

### DIFF
--- a/rt-thread/tools/menuconfig.py
+++ b/rt-thread/tools/menuconfig.py
@@ -27,6 +27,8 @@ import os
 import re
 import sys
 import shutil
+import hashlib
+import operator
 
 # make rtconfig.h from .config
 
@@ -37,7 +39,6 @@ def is_pkg_special_config(config_str):
         if config_str.startswith("PKG_") and (config_str.endswith('_PATH') or config_str.endswith('_VER')):
             return True
     return False
-
 
 def mk_rtconfig(filename):
     try:
@@ -96,6 +97,14 @@ def mk_rtconfig(filename):
     rtconfig.write('\n')
     rtconfig.write('#endif\n')
     rtconfig.close()
+
+
+def get_file_md5(file):
+    MD5 = hashlib.new('md5')
+    with open(file, 'r') as fp:
+        MD5.update(fp.read().encode('utf8'))
+        fp_md5 = MD5.hexdigest()
+        return fp_md5
 
 def config():
     mk_rtconfig('.config')
@@ -219,22 +228,22 @@ def menuconfig(RTT_ROOT):
     os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
 
     fn = '.config'
-
-    if os.path.isfile(fn):
-        mtime = os.path.getmtime(fn)
-    else:
-        mtime = -1
+    fn_old = '.config.old'
 
     kconfig_cmd = os.path.join(RTT_ROOT, 'tools', 'kconfig-frontends', 'kconfig-mconf')
     os.system(kconfig_cmd + ' Kconfig')
 
     if os.path.isfile(fn):
-        mtime2 = os.path.getmtime(fn)
+        if os.path.isfile(fn_old):
+            diff_eq = operator.eq(get_file_md5(fn), get_file_md5(fn_old))
+        else:
+            diff_eq = False
     else:
-        mtime2 = -1
+        sys.exit(-1)
 
     # make rtconfig.h
-    if mtime != mtime2:
+    if diff_eq == False:
+        shutil.copyfile(fn, fn_old)
         mk_rtconfig(fn)
 
 # guiconfig for windows and linux
@@ -249,22 +258,22 @@ def guiconfig(RTT_ROOT):
     os.environ['PKGS_ROOT'] = os.path.join(env_dir, 'packages')
 
     fn = '.config'
-
-    if os.path.isfile(fn):
-        mtime = os.path.getmtime(fn)
-    else:
-        mtime = -1
+    fn_old = '.config.old'
 
     sys.argv = ['guiconfig', 'Kconfig'];
     pyguiconfig._main()
 
     if os.path.isfile(fn):
-        mtime2 = os.path.getmtime(fn)
+        if os.path.isfile(fn_old):
+            diff_eq = operator.eq(get_file_md5(fn), get_file_md5(fn_old))
+        else:
+            diff_eq = False
     else:
-        mtime2 = -1
+        sys.exit(-1)
 
     # make rtconfig.h
-    if mtime != mtime2:
+    if diff_eq == False:
+        shutil.copyfile(fn, fn_old)
         mk_rtconfig(fn)
 
 


### PR DESCRIPTION
優化通過備份 **.config** 文件爲 **.config.old**，使用 **diff 工具對比 .config 文件是否發生變化**，而不再**根據 .config 文件的時間戳對**比 .config 文件是否發生變化：
實際的使用場景：當通過 menuconfig  **修改了配置選項**  重新生成了 .config 後可以正常產生 rtconfig.h 頭文件，
但是如果通過 git checkout .config 回退到初始的 .config 或者其他方式手動修改了 .config 文件，在這些
場景，即使執行了 **scons --menuconfig**， 也不會更新 rtconfig.h 頭文件，除非強制 **添加 --useconfig .config** 來強制更新 rtconfig.h ，因爲更新的前提是通過 **scons --menuconfig** 配置時候手動對選項進行了修改。該 patch 通過**備份最近一次的 .config 文件爲 .config.old**，然後通過 **diff** 工具來對比 .config 文件是否發生改動，也可以方便後期對比 .config 配置選項的差異。
