### PR TITLE
【修复】未开启 FLASH_FS 时报错的问题

### DIFF
--- a/libraries/Kconfig
+++ b/libraries/Kconfig
@@ -304,11 +304,13 @@ menu "On-chip Peripheral"
         if BSP_USING_USBH
             menuconfig RT_USBH_MSTORAGE
                 bool "Enable Udisk Drivers"
+                select RT_USING_DFS
+                select RT_USING_DFS_ELMFAT
                 default n
                 if RT_USBH_MSTORAGE
                     config UDISK_MOUNTPOINT
-                    string "Udisk mount dir"
-                    default "/"
+                        string "Udisk mount dir"
+                        default "/"
                 endif
         endif
         

--- a/projects/art_pi_blink_led/board/port/filesystem.c
+++ b/projects/art_pi_blink_led/board/port/filesystem.c
@@ -19,10 +19,14 @@
 #error "Please define DFS_FILESYSTEM_TYPES_MAX more than 4"
 #endif
 
+#ifdef BSP_USING_SPI_FLASH_FS
+#include "fal.h"
+#endif
+
 #include <dfs_fs.h>
 #include "dfs_romfs.h"
 #include "drv_sdio.h"
-#include "fal.h"
+
 #define DBG_TAG "app.filesystem"
 #define DBG_LVL DBG_INFO
 #include <rtdbg.h>


### PR DESCRIPTION
未开启 `FLASH_FS` 时，`filesystem.c` 却` #include  fal.h` ，会导致编译报错