### PR TITLE
[update] Updated version number

### DIFF
--- a/RealThread_STMH750-ART-Pi.yaml
+++ b/RealThread_STMH750-ART-Pi.yaml
@@ -1,6 +1,6 @@
 ---
 yaml_version: 3
-pkg_version: 1.1.0
+pkg_version: 1.2.0
 pkg_vendor: RealThread
 pkg_type: Board_Support_Packages
 board:

--- a/projects/README.md
+++ b/projects/README.md
@@ -7,6 +7,8 @@ ART-Pi 开源项目如下表所示：
 | [art_pi_blink_led](./art_pi_blink_led)    | 实现 LED 闪烁功能,可作为二次开发的基础工程 |
 | [art_pi_bootloader](./art_pi_bootloader) | 实现程序从 0x08000000 跳转到 0x90000000 |
 | [art_pi_factory](./art_pi_factory) | 实现 webnet. ART-Pi 的出厂DEMO |
+| [art_pi_gc0328c_camera](./art_pi_gc0328c_camera) | 实现 gc0328c 摄像头拍照，并显示在多媒体扩展板 |
+| [art_pi_sensor485_app](./art_pi_sensor485_app) | 实现 串口模拟发送传感器数据，通过 MQTT 上传到手机上的 APP |
 | [art_pi_wifi](./art_pi_wifi) | 实现 wifi 联网 |
 | [industry_io_gateway](./industry_io_gateway) | 实现 modbustcp2rtu 及 ftp |
 | [art_pi_net_player](./art_pi_net_player) | 实现 MP3 音乐播放，支持本地音乐和网易云音乐 |


### PR DESCRIPTION
解决问题：

开发者在打算提交工程代码的时候，如果已经在 RTT Studio 中安装了 V1.1.0 的版本那么就会出现导入 master 的 zip 失败的情况，必须修改 yaml 中的版本号，为了让开发者更加方便的测试，应该把 master yaml 文件中的版本号高于SDK release 的版本号。