### PR TITLE
【修复】 QSPI FLASH 会初始化失败的问题

### DIFF
--- a/projects/art_pi_bootloader/applications/boot.c
+++ b/projects/art_pi_bootloader/applications/boot.c
@@ -10,6 +10,7 @@
 
 #include <rthw.h>
 #include <rtthread.h>
+#include "w25qxx.h"
 
 void rt_application_init(void);
 void rt_hw_board_init(void);
@@ -141,6 +142,11 @@ int rtthread_startup(void)
     rt_hw_spin_lock(&_cpus_lock);
 #endif /*RT_USING_SMP*/
 
+    MX_QUADSPI_Init();
+
+    W25QXX_ExitQPIMode();
+    W25QXX_Reset();
+    
     /* start scheduler */
     rt_system_scheduler_start();
 

--- a/projects/art_pi_bootloader/applications/w25qxx.c
+++ b/projects/art_pi_bootloader/applications/w25qxx.c
@@ -25,7 +25,7 @@ uint16_t w25qxx_mid = W25Q128;
 /*----------------------------------------------------------------------------*/
 QSPI_HandleTypeDef hqspi;
 
-static void MX_QUADSPI_Init(void)
+void MX_QUADSPI_Init(void)
 {
     hqspi.Instance            = QUADSPI;
     hqspi.Init.ClockPrescaler = 1;

--- a/projects/art_pi_bootloader/applications/w25qxx.h
+++ b/projects/art_pi_bootloader/applications/w25qxx.h
@@ -92,4 +92,5 @@ void W25QXX_WaitBusy(void);
 void W25QXX_Reset(void);
 
 void W25Q_Memory_Mapped_Enable(void);
+void MX_QUADSPI_Init(void);
 #endif


### PR DESCRIPTION
在调试 bootloader 期间，如果 FLASH 已经进入 QSPI 模式，那么会导致板子复位之后第二次初始化失败，所以需要在系统上电前，DISABLE QSPI FLASH